### PR TITLE
fix a description typo related to imshow 

### DIFF
--- a/home-assignments/HA1/HA1.ipynb
+++ b/home-assignments/HA1/HA1.ipynb
@@ -910,7 +910,7 @@
     "            + \"use the `ToTensor` transformation to convert the images to tensors.\"\n",
     "        )\n",
     "\n",
-    "    # The imshow commands expects a `numpy array` with shape (3, width, height)\n",
+    "    # The imshow commands expects a `numpy array` with shape (height, width, 3)\n",
     "    # We rearrange the dimensions with `permute` and then convert it to `numpy`\n",
     "    image_data = image_tensor.permute(1, 2, 0).numpy()\n",
     "    height, width, _ = image_data.shape\n",


### PR DESCRIPTION
Fix a description typo related to imshow for matplotlib. 

An analysis has been added inside the issue which describe the issue with supported code.  This PR resolve https://github.com/dml-cth/deep-machine-learning/issues/3